### PR TITLE
fix/АВА-5

### DIFF
--- a/src/shared/ui-kit/input-password/styles.module.css
+++ b/src/shared/ui-kit/input-password/styles.module.css
@@ -5,7 +5,7 @@
 }
 
 .input {
-  padding: 0 0 0 10px;
+  padding: 0 35px 0 10px;
   transition: var(--transition-common);
   height: 38px;
   font-size: 16px;


### PR DESCRIPTION
Отодвинул иконку 'ключ' от иконки 'глаз', в поле пароль формы входа.
![image](https://github.com/Studio-Yandex-Practicum/lomaya_baryery_frontend/assets/76275676/e5e7ce3a-d0b5-4299-8e2d-287c541e2efd)
