### PR TITLE
Деактивировал кнопки "предыдущий/следующий отчёт" у первого/последнего отчёта

### DIFF
--- a/src/entities/report/ui/slider-controls/index.tsx
+++ b/src/entities/report/ui/slider-controls/index.tsx
@@ -22,6 +22,8 @@ export function SliderControls({
   totalSlides,
   extClassName,
 }: SliderControlsProps) {
+  const prevIconColor = disablePrev ? 'gray' : 'blue-dark';
+  const nextIconColor = disableNext ? 'gray' : 'blue-dark';
   return (
     <nav className={cn(styles.container, extClassName)}>
       <Button
@@ -31,7 +33,7 @@ export function SliderControls({
         onClick={onPrev}
         disabled={disablePrev}
       >
-        <ArrowLeftIcon color="blue-dark" />
+        <ArrowLeftIcon color={prevIconColor} />
         Предыдущий отчёт
       </Button>
       <p className="text text_type_main-default text_color_secondary m-0">{`${currentSlide} из ${totalSlides}`}</p>
@@ -43,7 +45,7 @@ export function SliderControls({
         disabled={disableNext}
       >
         Следующий отчёт
-        <ArrowRightIcon color="blue-dark" />
+        <ArrowRightIcon color={nextIconColor} />
       </Button>
     </nav>
   );

--- a/src/widgets/reports-slider/ui/index.tsx
+++ b/src/widgets/reports-slider/ui/index.tsx
@@ -70,6 +70,8 @@ export function ReportsSlider({ reportId, extClassName }: ReportsSliderProps) {
         currentSlide={cur + 1}
         onPrev={handlePrev}
         onNext={handleNext}
+        disablePrev={cur === 0}
+        disableNext={cur === list.length - 1}
       />
     </>
   );


### PR DESCRIPTION
На странице просмотра отчёта, сделал кнопки "Предыдущий/Следующий отчёт" не активными, при условии, что пользователь просматривает первый/последний отчет. 

![image](https://github.com/Studio-Yandex-Practicum/lomaya_baryery_frontend/assets/76275676/1c9d3d72-5626-45c4-b419-08326afcf5be)
